### PR TITLE
Restore Thymeleaf support for Java 8 runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <thymeleaf.version>3.1.2.RELEASE</thymeleaf.version>
+        <thymeleaf.version>3.0.15.RELEASE</thymeleaf.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/example/web/Servlets.java
+++ b/src/main/java/com/example/web/Servlets.java
@@ -4,17 +4,14 @@ import org.thymeleaf.TemplateEngine; // Thymeleaf 模板引擎
 import org.thymeleaf.context.WebContext; // Thymeleaf Web 上下文
 import org.thymeleaf.templatemode.TemplateMode; // 模板模式配置
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver; // 类加载器资源解析器
-import org.thymeleaf.web.servlet.IServletWebExchange; // Servlet 交换对象
-import org.thymeleaf.web.servlet.JavaxServletWebApplication; // Thymeleaf Servlet 集成入口
-
 import javax.servlet.ServletContext; // Servlet 上下文
 import javax.servlet.http.HttpServletRequest; // 请求对象
 import javax.servlet.http.HttpServletResponse; // 响应对象
 import java.nio.charset.StandardCharsets; // 字符集常量
+import java.util.Locale; // 本地化对象
 
 public final class Servlets { // 提供静态辅助方法
     private static final TemplateEngine TEMPLATE_ENGINE = createTemplateEngine(); // 预先构建的模板引擎实例
-    private static volatile JavaxServletWebApplication webApplication; // 缓存 Thymeleaf Web 应用
 
     private Servlets() { // 禁止实例化
     }
@@ -45,23 +42,11 @@ public final class Servlets { // 提供静态辅助方法
     }
 
     public static WebContext webContext(HttpServletRequest request, HttpServletResponse response, ServletContext servletContext) { // 构建 Thymeleaf 上下文
-        JavaxServletWebApplication application = getWebApplication(servletContext); // 获取 Web 应用桥接对象
-        IServletWebExchange exchange = application.buildExchange(request, response); // 创建 Servlet 交换对象
-        return new WebContext(exchange, exchange.getLocale()); // 使用交换对象和本地化信息创建上下文
-    }
-
-    private static JavaxServletWebApplication getWebApplication(ServletContext servletContext) { // 懒加载 Web 应用
-        JavaxServletWebApplication current = webApplication; // 读取缓存引用
-        if (current == null) { // 首次访问时
-            synchronized (Servlets.class) { // 双重检查锁保证线程安全
-                current = webApplication; // 再次读取
-                if (current == null) { // 仍未初始化
-                    current = JavaxServletWebApplication.buildApplication(servletContext); // 创建新实例
-                    webApplication = current; // 缓存起来
-                }
-            }
+        Locale locale = request.getLocale(); // 读取请求首选语言
+        if (locale == null) { // 兼容部分容器可能返回 null 的情况
+            locale = Locale.getDefault(); // 回退到系统默认区域
         }
-        return current; // 返回可用实例
+        return new WebContext(request, response, servletContext, locale); // 使用经典构造函数创建上下文
     }
 
     private static TemplateEngine createTemplateEngine() { // 构建 Thymeleaf 模板引擎


### PR DESCRIPTION
## Summary
- downgrade Thymeleaf dependency to 3.0.15.RELEASE to match Java 8 requirements
- simplify the Servlet utility to use the legacy WebContext constructor compatible with Java 8 containers
- add locale fallback when servlet containers do not provide a locale on the request

## Testing
- `./mvnw -DskipTests package` *(fails: unable to download Maven wrapper due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c2c1d6f483289d130f9e8ec6b988